### PR TITLE
Performance improvement on map.__contains__, making it O(1).

### DIFF
--- a/python/pycrdt/_pycrdt.pyi
+++ b/python/pycrdt/_pycrdt.pyi
@@ -213,6 +213,9 @@ class Map:
         """Unsubscribes previously subscribed event callback identified by given
         `subscription`."""
 
+    def has(self, txn: Transaction, key: str) -> bool:
+        """Returns true if the given key exists in the map."""
+
 class XmlFragment:
     def parent(self) -> XmlFragment | XmlElement | XmlText | None:
         """Returns the parent of the XML fragment, if any."""

--- a/src/map.rs
+++ b/src/map.rs
@@ -141,6 +141,14 @@ impl Map {
         Python::with_gil(|py| PyString::new(py, s.as_str()).into())
     }
 
+    /// Returns true if the given key exists in the map.
+    fn has(&self, txn: &mut Transaction, key: &str) -> PyResult<bool> {
+        let mut t0 = txn.transaction();
+        let t1 = t0.as_mut().unwrap();
+        let t = t1.as_ref();
+        Ok(self.map.get(t, key).is_some())
+    }
+
     pub fn observe(&mut self, py: Python<'_>, f: PyObject) -> PyResult<Py<Subscription>> {
         let sub = self.map
             .observe(move |txn, e| {


### PR DESCRIPTION
Improvement:
Make `y.Map.__contains__` in O(1).


Previously, it uses `map.keys()`, which returns an iterator of keys, whose time complexity is O(N).

This PR improves performance in checking keys in large maps.