### PR TITLE
Fix elide warnings in `txn` methods

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -217,7 +217,7 @@ impl ArrayEvent {
         unsafe { self.event.as_ref().unwrap() }
     }
 
-    fn txn(&self) -> &TransactionMut {
+    fn txn(&self) -> &TransactionMut<'_> {
         unsafe { self.txn.as_ref().unwrap() }
     }
 }

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -199,7 +199,7 @@ impl TransactionEvent {
     fn event(&self) -> &TransactionCleanupEvent {
         unsafe { self.event.as_ref().unwrap() }
     }
-    fn txn(&self) -> &TransactionMut {
+    fn txn(&self) -> &TransactionMut<'_> {
         unsafe { self.txn.as_ref().unwrap() }
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -207,7 +207,7 @@ impl MapEvent {
         unsafe { self.event.as_ref().unwrap() }
     }
 
-    fn txn(&self) -> &TransactionMut {
+    fn txn(&self) -> &TransactionMut<'_> {
         unsafe { self.txn.as_ref().unwrap() }
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -178,7 +178,7 @@ impl TextEvent {
         unsafe { self.event.as_ref().unwrap() }
     }
 
-    fn txn(&self) -> &TransactionMut {
+    fn txn(&self) -> &TransactionMut<'_> {
         unsafe { self.txn.as_ref().unwrap() }
     }
 }


### PR DESCRIPTION
Addresses warnings highlighted in https://github.com/y-crdt/pycrdt/pull/293#issuecomment-3310974814.