### PR TITLE
fix: Text indices are character-based; add Doc(offset_kind=...)

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -45,6 +45,8 @@
       - handle_sync_message
       - get_state
       - get_update
+      - get_utf8_index
+      - get_utf16_index
       - merge_updates
       - read_message
       - write_message

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -315,6 +315,22 @@ print(str(text))
 
 Undoing a change doesn't remove the change from the document's history, but applies a change that is the opposite of the previous change.
 
+## Text indices and Unicode
+
+All `Text` methods take Python character (code point) indices, like a Python `str`:
+
+```py
+from pycrdt import Doc, Text
+
+doc = Doc()
+doc["text"] = text = Text("A📊B")
+text.insert(2, "X")  # character index, even though 📊 is 4 UTF-8 bytes
+print(str(text))
+# prints: "A📊XB"
+```
+
+Internally, yrs counts text positions in the units selected by the document's `offset_kind`, and pycrdt converts character indices to those units. The default is `"utf8"` (byte offsets, the yrs default). Passing `offset_kind="utf16"` makes yrs count in UTF-16 code units, which matches the index semantics of JS [yjs](https://github.com/yjs/yjs) (JavaScript strings are UTF-16). The setting doesn't affect the update wire format — documents with different offset kinds stay in sync — but it matters when raw yrs offsets are shared with yjs peers, for instance through sticky indices or event deltas. The conversion helpers [get_utf8_index][pycrdt.get_utf8_index] and [get_utf16_index][pycrdt.get_utf16_index] are available for code that needs to do the same conversion.
+
 ## Type annotations
 
 `Array`, `Map` and `Doc` can be type-annotated for static type analysis. For instance, here is how to declare a `Doc` where all root types are `Array`s of `int`s:

--- a/python/pycrdt/__init__.py
+++ b/python/pycrdt/__init__.py
@@ -35,6 +35,8 @@ from ._sync import write_message as write_message
 from ._sync import write_var_uint as write_var_uint
 from ._text import Text as Text
 from ._text import TextEvent as TextEvent
+from ._text import get_utf8_index as get_utf8_index
+from ._text import get_utf16_index as get_utf16_index
 from ._transaction import NewTransaction as NewTransaction
 from ._transaction import ReadTransaction as ReadTransaction
 from ._transaction import Transaction as Transaction

--- a/python/pycrdt/_base.py
+++ b/python/pycrdt/_base.py
@@ -72,8 +72,7 @@ class BaseDoc:
             doc = _Doc(client_id, skip_gc, offset_kind)
         elif offset_kind is not None and offset_kind != doc.offset_kind:
             raise ValueError(
-                f"offset_kind={offset_kind!r} does not match doc.offset_kind="
-                f"{doc.offset_kind!r}"
+                f"offset_kind={offset_kind!r} does not match doc.offset_kind={doc.offset_kind!r}"
             )
         self._doc = doc
         self._txn = None

--- a/python/pycrdt/_base.py
+++ b/python/pycrdt/_base.py
@@ -61,6 +61,7 @@ class BaseDoc:
         *,
         client_id: int | None = None,
         skip_gc: bool | None = None,
+        offset_kind: str | None = None,
         doc: _Doc | None = None,
         Model=None,
         allow_multithreading: bool = False,
@@ -68,7 +69,12 @@ class BaseDoc:
     ) -> None:
         super().__init__(**data)
         if doc is None:
-            doc = _Doc(client_id, skip_gc)
+            doc = _Doc(client_id, skip_gc, offset_kind)
+        elif offset_kind is not None and offset_kind != doc.offset_kind:
+            raise ValueError(
+                f"offset_kind={offset_kind!r} does not match doc.offset_kind="
+                f"{doc.offset_kind!r}"
+            )
         self._doc = doc
         self._txn = None
         self._exceptions = []

--- a/python/pycrdt/_base.py
+++ b/python/pycrdt/_base.py
@@ -61,7 +61,7 @@ class BaseDoc:
         *,
         client_id: int | None = None,
         skip_gc: bool | None = None,
-        offset_kind: str | None = None,
+        offset_kind: Literal["utf8", "utf16"] | None = None,
         doc: _Doc | None = None,
         Model=None,
         allow_multithreading: bool = False,

--- a/python/pycrdt/_doc.py
+++ b/python/pycrdt/_doc.py
@@ -48,6 +48,7 @@ class Doc(BaseDoc, Generic[T]):
         *,
         client_id: int | None = None,
         skip_gc: bool | None = None,
+        offset_kind: str | None = None,
         doc: _Doc | None = None,
         Model=None,
         allow_multithreading: bool = False,
@@ -58,11 +59,18 @@ class Doc(BaseDoc, Generic[T]):
             client_id: An optional client ID for the document.
             skip_gc: Whether to skip garbage collection on deleted collections
                 on transaction commit.
+            offset_kind: How yrs counts text positions internally. ``"utf8"``
+                (the yrs default) uses byte offsets; ``"utf16"`` uses UTF-16
+                code unit offsets and is required for cross-runtime
+                compatibility with JS yjs. ``None`` (default) selects the yrs
+                default of ``"utf8"``. Regardless of this setting, the public
+                ``Text`` API always takes Python character indices.
             allow_multithreading: Whether to allow the document to be used in different threads.
         """
         super().__init__(
             client_id=client_id,
             skip_gc=skip_gc,
+            offset_kind=offset_kind,
             doc=doc,
             Model=Model,
             allow_multithreading=allow_multithreading,
@@ -85,6 +93,15 @@ class Doc(BaseDoc, Generic[T]):
     def client_id(self) -> int:
         """The document client ID."""
         return self._doc.client_id()
+
+    @property
+    def offset_kind(self) -> str:
+        """The text offset kind used internally by yrs.
+
+        Returns ``"utf8"`` or ``"utf16"``. See [Doc.__init__][pycrdt.Doc.__init__]
+        for the meaning.
+        """
+        return self._doc.offset_kind
 
     def transaction(self, origin: Any = None) -> Transaction:
         """

--- a/python/pycrdt/_doc.py
+++ b/python/pycrdt/_doc.py
@@ -48,7 +48,7 @@ class Doc(BaseDoc, Generic[T]):
         *,
         client_id: int | None = None,
         skip_gc: bool | None = None,
-        offset_kind: str | None = None,
+        offset_kind: Literal["utf8", "utf16"] | None = None,
         doc: _Doc | None = None,
         Model=None,
         allow_multithreading: bool = False,
@@ -95,7 +95,7 @@ class Doc(BaseDoc, Generic[T]):
         return self._doc.client_id()
 
     @property
-    def offset_kind(self) -> str:
+    def offset_kind(self) -> Literal["utf8", "utf16"]:
         """The text offset kind used internally by yrs.
 
         Returns ``"utf8"`` or ``"utf16"``. See [Doc.__init__][pycrdt.Doc.__init__]

--- a/python/pycrdt/_doc.py
+++ b/python/pycrdt/_doc.py
@@ -61,10 +61,16 @@ class Doc(BaseDoc, Generic[T]):
                 on transaction commit.
             offset_kind: How yrs counts text positions internally. ``"utf8"``
                 (the yrs default) uses byte offsets; ``"utf16"`` uses UTF-16
-                code unit offsets and is required for cross-runtime
-                compatibility with JS yjs. ``None`` (default) selects the yrs
-                default of ``"utf8"``. Regardless of this setting, the public
-                ``Text`` API always takes Python character indices.
+                code unit offsets, matching the index semantics of JS yjs.
+                ``None`` (default) selects the yrs default of ``"utf8"``.
+                The setting doesn't affect the update wire format, but it
+                matters when raw yrs offsets are shared with yjs peers (e.g.
+                sticky indices, event deltas). It applies to this document
+                only: a subdocument carries the offset kind chosen by the
+                peer that created it. Regardless of this setting, the public
+                ``Text`` API takes Python character indices into the text
+                content as returned by ``str()`` (embedded objects are not
+                accounted for).
             allow_multithreading: Whether to allow the document to be used in different threads.
         """
         super().__init__(

--- a/python/pycrdt/_pycrdt.pyi
+++ b/python/pycrdt/_pycrdt.pyi
@@ -17,7 +17,12 @@ class Snapshot:
 class Doc:
     """Shared document."""
 
-    def __init__(self, client_id: int | None, skip_gc: bool | None) -> None:
+    def __init__(
+        self,
+        client_id: int | None,
+        skip_gc: bool | None,
+        offset_kind: str | None,
+    ) -> None:
         """Create a new document with an optional global client ID.
         If no client ID is passed, a random one will be generated."""
 
@@ -27,6 +32,10 @@ class Doc:
 
     def client_id(self) -> int:
         """Returns the document unique client identifier."""
+
+    @property
+    def offset_kind(self) -> str:
+        """Returns the offset kind ('utf8' or 'utf16')."""
 
     def guid(self) -> int:
         """Returns the document globally unique identifier."""

--- a/python/pycrdt/_pycrdt.pyi
+++ b/python/pycrdt/_pycrdt.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Generic, Iterator, TypeVar
+from typing import Any, Callable, Generic, Iterator, Literal, TypeVar
 
 class Snapshot:
     """A snapshot of a document's state at a given point in time."""
@@ -21,7 +21,7 @@ class Doc:
         self,
         client_id: int | None,
         skip_gc: bool | None,
-        offset_kind: str | None,
+        offset_kind: Literal["utf8", "utf16"] | None,
     ) -> None:
         """Create a new document with an optional global client ID.
         If no client ID is passed, a random one will be generated."""
@@ -34,7 +34,7 @@ class Doc:
         """Returns the document unique client identifier."""
 
     @property
-    def offset_kind(self) -> str:
+    def offset_kind(self) -> Literal["utf8", "utf16"]:
         """Returns the offset kind ('utf8' or 'utf16')."""
 
     def guid(self) -> int:

--- a/python/pycrdt/_text.py
+++ b/python/pycrdt/_text.py
@@ -15,8 +15,7 @@ def _char_to_utf16(text: str, char_index: int) -> int:
     """Convert a Python character (code point) index to a UTF-16 code unit index.
 
     Characters outside the Basic Multilingual Plane (e.g. emoji) occupy 2
-    UTF-16 code units but only 1 Python character.  The underlying yrs library
-    uses UTF-16 offsets, so all indices passed to it must be converted.
+    UTF-16 code units but only 1 Python character.
 
     For pure-ASCII / BMP text this is a no-op (returns ``char_index``
     unchanged).
@@ -27,6 +26,25 @@ def _char_to_utf16(text: str, char_index: int) -> int:
     # Count characters that need a surrogate pair (code point > 0xFFFF)
     extra = sum(1 for ch in prefix if ord(ch) > 0xFFFF)
     return char_index + extra
+
+
+def _char_to_utf8(text: str, char_index: int) -> int:
+    """Convert a Python character (code point) index to a UTF-8 byte index."""
+    if char_index == 0:
+        return 0
+    return len(text[:char_index].encode("utf-8"))
+
+
+def _char_to_offset(text: str, char_index: int, offset_kind: str) -> int:
+    if offset_kind == "utf16":
+        return _char_to_utf16(text, char_index)
+    return _char_to_utf8(text, char_index)
+
+
+def _single_char_unit_len(char: str, offset_kind: str) -> int:
+    if offset_kind == "utf16":
+        return 2 if ord(char) > 0xFFFF else 1
+    return len(char.encode("utf-8"))
 
 
 class Text(Sequence):
@@ -147,8 +165,8 @@ class Text(Sequence):
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
             current = str(self)
-            utf16_index = _char_to_utf16(current, len(current))
-            self.integrated.insert(txn._txn, utf16_index, value)
+            offset = _char_to_offset(current, len(current), self.doc.offset_kind)
+            self.integrated.insert(txn._txn, offset, value)
             return self
 
     def _check_slice(self, key: slice) -> tuple[int, int]:
@@ -190,18 +208,19 @@ class Text(Sequence):
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
             current = str(self)
+            ok = self.doc.offset_kind
             if isinstance(key, int):
-                utf16_idx = _char_to_utf16(current, key)
-                char_at = current[key]
-                utf16_len = 2 if ord(char_at) > 0xFFFF else 1
-                self.integrated.remove_range(txn._txn, utf16_idx, utf16_len)
+                offset = _char_to_offset(current, key, ok)
+                unit_len = _single_char_unit_len(current[key], ok)
+                self.integrated.remove_range(txn._txn, offset, unit_len)
             elif isinstance(key, slice):
                 start, stop = self._check_slice(key)
-                length = stop - start
-                if length > 0:
-                    utf16_start = _char_to_utf16(current, start)
-                    utf16_stop = _char_to_utf16(current, stop)
-                    self.integrated.remove_range(txn._txn, utf16_start, utf16_stop - utf16_start)
+                if stop - start > 0:
+                    offset_start = _char_to_offset(current, start, ok)
+                    offset_stop = _char_to_offset(current, stop, ok)
+                    self.integrated.remove_range(
+                        txn._txn, offset_start, offset_stop - offset_start
+                    )
             else:
                 raise RuntimeError(f"Index not supported: {key}")
 
@@ -241,25 +260,25 @@ class Text(Sequence):
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
             current = str(self)
+            ok = self.doc.offset_kind
             if isinstance(key, int):
                 value_len = len(value)
                 if value_len != 1:
                     raise RuntimeError(
                         f"Single item assigned value must have a length of 1, not {value_len}"
                     )
-                utf16_idx = _char_to_utf16(current, key)
-                char_at = current[key]
-                utf16_len = 2 if ord(char_at) > 0xFFFF else 1
-                self.integrated.remove_range(txn._txn, utf16_idx, utf16_len)
-                self.integrated.insert(txn._txn, utf16_idx, value)
+                offset = _char_to_offset(current, key, ok)
+                unit_len = _single_char_unit_len(current[key], ok)
+                self.integrated.remove_range(txn._txn, offset, unit_len)
+                self.integrated.insert(txn._txn, offset, value)
             elif isinstance(key, slice):
                 start, stop = self._check_slice(key)
-                utf16_start = _char_to_utf16(current, start)
-                utf16_stop = _char_to_utf16(current, stop)
-                length = utf16_stop - utf16_start
+                offset_start = _char_to_offset(current, start, ok)
+                offset_stop = _char_to_offset(current, stop, ok)
+                length = offset_stop - offset_start
                 if length > 0:
-                    self.integrated.remove_range(txn._txn, utf16_start, length)
-                self.integrated.insert(txn._txn, utf16_start, value)
+                    self.integrated.remove_range(txn._txn, offset_start, length)
+                self.integrated.insert(txn._txn, offset_start, value)
             else:
                 raise RuntimeError(f"Index not supported: {key}")
 
@@ -284,9 +303,9 @@ class Text(Sequence):
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
             current = str(self)
-            utf16_index = _char_to_utf16(current, index)
+            offset = _char_to_offset(current, index, self.doc.offset_kind)
             self.integrated.insert(
-                txn._txn, utf16_index, value, iter(attrs.items()) if attrs is not None else None
+                txn._txn, offset, value, iter(attrs.items()) if attrs is not None else None
             )
 
     def insert_embed(self, index: int, value: Any, attrs: dict[str, Any] | None = None) -> None:
@@ -301,9 +320,9 @@ class Text(Sequence):
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
             current = str(self)
-            utf16_index = _char_to_utf16(current, index)
+            offset = _char_to_offset(current, index, self.doc.offset_kind)
             self.integrated.insert_embed(
-                txn._txn, utf16_index, value, iter(attrs.items()) if attrs is not None else None
+                txn._txn, offset, value, iter(attrs.items()) if attrs is not None else None
             )
 
     def format(self, start: int, stop: int, attrs: dict[str, Any]) -> None:
@@ -319,11 +338,12 @@ class Text(Sequence):
             self._forbid_read_transaction(txn)
             start, stop = self._check_slice(slice(start, stop))
             current = str(self)
-            utf16_start = _char_to_utf16(current, start)
-            utf16_stop = _char_to_utf16(current, stop)
-            length = utf16_stop - utf16_start
+            ok = self.doc.offset_kind
+            offset_start = _char_to_offset(current, start, ok)
+            offset_stop = _char_to_offset(current, stop, ok)
+            length = offset_stop - offset_start
             if length > 0:
-                self.integrated.format(txn._txn, utf16_start, length, iter(attrs.items()))
+                self.integrated.format(txn._txn, offset_start, length, iter(attrs.items()))
 
     def diff(self) -> list[tuple[Any, dict[str, Any] | None]]:
         """

--- a/python/pycrdt/_text.py
+++ b/python/pycrdt/_text.py
@@ -11,6 +11,36 @@ if TYPE_CHECKING:
     from ._doc import Doc
 
 
+def _char_to_utf16(text: str, char_index: int) -> int:
+    """Convert a Python character (code point) index to a UTF-16 code unit index.
+
+    Characters outside the Basic Multilingual Plane (e.g. emoji) occupy 2
+    UTF-16 code units but only 1 Python character.  The underlying yrs library
+    uses UTF-16 offsets, so all indices passed to it must be converted.
+
+    For pure-ASCII / BMP text this is a no-op (returns ``char_index``
+    unchanged).
+    """
+    if char_index == 0:
+        return 0
+    prefix = text[:char_index]
+    # Count characters that need a surrogate pair (code point > 0xFFFF)
+    extra = sum(1 for ch in prefix if ord(ch) > 0xFFFF)
+    return char_index + extra
+
+
+def _utf16_to_char(text: str, utf16_index: int) -> int:
+    """Convert a UTF-16 code unit index back to a Python character index."""
+    char_idx = 0
+    utf16_idx = 0
+    for ch in text:
+        if utf16_idx >= utf16_index:
+            break
+        utf16_idx += 2 if ord(ch) > 0xFFFF else 1
+        char_idx += 1
+    return char_idx
+
+
 class Text(Sequence):
     """
     A shared data type used for collaborative text editing, similar to a Python `str`.
@@ -89,10 +119,10 @@ class Text(Sequence):
         ```
 
         Returns:
-            The length of the text.
+            The length of the text (in Python characters, not UTF-16 code units).
         """
-        with self.doc.transaction() as txn:
-            return self.integrated.len(txn._txn)
+        # Return Python character count, not yrs UTF-16 code unit count
+        return len(str(self))
 
     def __str__(self) -> str:
         """
@@ -169,13 +199,19 @@ class Text(Sequence):
         """
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
+            current = str(self)
             if isinstance(key, int):
-                self.integrated.remove_range(txn._txn, key, 1)
+                utf16_idx = _char_to_utf16(current, key)
+                char_at = current[key]
+                utf16_len = 2 if ord(char_at) > 0xFFFF else 1
+                self.integrated.remove_range(txn._txn, utf16_idx, utf16_len)
             elif isinstance(key, slice):
                 start, stop = self._check_slice(key)
                 length = stop - start
                 if length > 0:
-                    self.integrated.remove_range(txn._txn, start, length)
+                    utf16_start = _char_to_utf16(current, start)
+                    utf16_stop = _char_to_utf16(current, stop)
+                    self.integrated.remove_range(txn._txn, utf16_start, utf16_stop - utf16_start)
             else:
                 raise RuntimeError(f"Index not supported: {key}")
 
@@ -214,20 +250,26 @@ class Text(Sequence):
         """
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
+            current = str(self)
             if isinstance(key, int):
                 value_len = len(value)
                 if value_len != 1:
                     raise RuntimeError(
                         f"Single item assigned value must have a length of 1, not {value_len}"
                     )
-                del self[key]
-                self.integrated.insert(txn._txn, key, value)
+                utf16_idx = _char_to_utf16(current, key)
+                char_at = current[key]
+                utf16_len = 2 if ord(char_at) > 0xFFFF else 1
+                self.integrated.remove_range(txn._txn, utf16_idx, utf16_len)
+                self.integrated.insert(txn._txn, utf16_idx, value)
             elif isinstance(key, slice):
                 start, stop = self._check_slice(key)
-                length = stop - start
+                utf16_start = _char_to_utf16(current, start)
+                utf16_stop = _char_to_utf16(current, stop)
+                length = utf16_stop - utf16_start
                 if length > 0:
-                    self.integrated.remove_range(txn._txn, start, length)
-                self.integrated.insert(txn._txn, start, value)
+                    self.integrated.remove_range(txn._txn, utf16_start, length)
+                self.integrated.insert(txn._txn, utf16_start, value)
             else:
                 raise RuntimeError(f"Index not supported: {key}")
 
@@ -251,8 +293,10 @@ class Text(Sequence):
         """
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
+            current = str(self)
+            utf16_index = _char_to_utf16(current, index)
             self.integrated.insert(
-                txn._txn, index, value, iter(attrs.items()) if attrs is not None else None
+                txn._txn, utf16_index, value, iter(attrs.items()) if attrs is not None else None
             )
 
     def insert_embed(self, index: int, value: Any, attrs: dict[str, Any] | None = None) -> None:
@@ -266,8 +310,10 @@ class Text(Sequence):
         """
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
+            current = str(self)
+            utf16_index = _char_to_utf16(current, index)
             self.integrated.insert_embed(
-                txn._txn, index, value, iter(attrs.items()) if attrs is not None else None
+                txn._txn, utf16_index, value, iter(attrs.items()) if attrs is not None else None
             )
 
     def format(self, start: int, stop: int, attrs: dict[str, Any]) -> None:
@@ -282,9 +328,12 @@ class Text(Sequence):
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
             start, stop = self._check_slice(slice(start, stop))
-            length = stop - start
+            current = str(self)
+            utf16_start = _char_to_utf16(current, start)
+            utf16_stop = _char_to_utf16(current, stop)
+            length = utf16_stop - utf16_start
             if length > 0:
-                self.integrated.format(txn._txn, start, length, iter(attrs.items()))
+                self.integrated.format(txn._txn, utf16_start, length, iter(attrs.items()))
 
     def diff(self) -> list[tuple[Any, dict[str, Any] | None]]:
         """

--- a/python/pycrdt/_text.py
+++ b/python/pycrdt/_text.py
@@ -230,9 +230,7 @@ class Text(Sequence):
                 if stop - start > 0:
                     offset_start = _char_to_offset(current, start, ok)
                     offset_stop = _char_to_offset(current, stop, ok)
-                    self.integrated.remove_range(
-                        txn._txn, offset_start, offset_stop - offset_start
-                    )
+                    self.integrated.remove_range(txn._txn, offset_start, offset_stop - offset_start)
             else:
                 raise RuntimeError(f"Index not supported: {key}")
 

--- a/python/pycrdt/_text.py
+++ b/python/pycrdt/_text.py
@@ -11,14 +11,19 @@ if TYPE_CHECKING:
     from ._doc import Doc
 
 
-def _char_to_utf16(text: str, char_index: int) -> int:
+def get_utf16_index(text: str, char_index: int) -> int:
     """Convert a Python character (code point) index to a UTF-16 code unit index.
 
     Characters outside the Basic Multilingual Plane (e.g. emoji) occupy 2
-    UTF-16 code units but only 1 Python character.
+    UTF-16 code units but only 1 Python character. For pure-ASCII / BMP
+    text this is a no-op.
 
-    For pure-ASCII / BMP text this is a no-op (returns ``char_index``
-    unchanged).
+    Args:
+        text: The string against which ``char_index`` is interpreted.
+        char_index: A Python (code point) index into ``text``.
+
+    Returns:
+        The corresponding UTF-16 code unit offset.
     """
     if char_index == 0:
         return 0
@@ -28,8 +33,16 @@ def _char_to_utf16(text: str, char_index: int) -> int:
     return char_index + extra
 
 
-def _char_to_utf8(text: str, char_index: int) -> int:
-    """Convert a Python character (code point) index to a UTF-8 byte index."""
+def get_utf8_index(text: str, char_index: int) -> int:
+    """Convert a Python character (code point) index to a UTF-8 byte index.
+
+    Args:
+        text: The string against which ``char_index`` is interpreted.
+        char_index: A Python (code point) index into ``text``.
+
+    Returns:
+        The corresponding UTF-8 byte offset.
+    """
     if char_index == 0:
         return 0
     return len(text[:char_index].encode("utf-8"))
@@ -37,8 +50,8 @@ def _char_to_utf8(text: str, char_index: int) -> int:
 
 def _char_to_offset(text: str, char_index: int, offset_kind: str) -> int:
     if offset_kind == "utf16":
-        return _char_to_utf16(text, char_index)
-    return _char_to_utf8(text, char_index)
+        return get_utf16_index(text, char_index)
+    return get_utf8_index(text, char_index)
 
 
 def _single_char_unit_len(char: str, offset_kind: str) -> int:
@@ -125,9 +138,8 @@ class Text(Sequence):
         ```
 
         Returns:
-            The length of the text (in Python characters, not UTF-16 code units).
+            The length of the text in Python characters.
         """
-        # Return Python character count, not yrs UTF-16 code unit count
         return len(str(self))
 
     def __str__(self) -> str:

--- a/python/pycrdt/_text.py
+++ b/python/pycrdt/_text.py
@@ -29,18 +29,6 @@ def _char_to_utf16(text: str, char_index: int) -> int:
     return char_index + extra
 
 
-def _utf16_to_char(text: str, utf16_index: int) -> int:
-    """Convert a UTF-16 code unit index back to a Python character index."""
-    char_idx = 0
-    utf16_idx = 0
-    for ch in text:
-        if utf16_idx >= utf16_index:
-            break
-        utf16_idx += 2 if ord(ch) > 0xFFFF else 1
-        char_idx += 1
-    return char_idx
-
-
 class Text(Sequence):
     """
     A shared data type used for collaborative text editing, similar to a Python `str`.
@@ -158,7 +146,9 @@ class Text(Sequence):
         """
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
-            self.integrated.insert(txn._txn, len(self), value)
+            current = str(self)
+            utf16_index = _char_to_utf16(current, len(current))
+            self.integrated.insert(txn._txn, utf16_index, value)
             return self
 
     def _check_slice(self, key: slice) -> tuple[int, int]:

--- a/python/pycrdt/_text.py
+++ b/python/pycrdt/_text.py
@@ -14,9 +14,11 @@ if TYPE_CHECKING:
 def get_utf16_index(text: str, char_index: int) -> int:
     """Convert a Python character (code point) index to a UTF-16 code unit index.
 
+    ``char_index`` is interpreted like a Python slice bound: negative values
+    count from the end of ``text`` and out-of-range values are clamped.
     Characters outside the Basic Multilingual Plane (e.g. emoji) occupy 2
     UTF-16 code units but only 1 Python character. For pure-ASCII / BMP
-    text this is a no-op.
+    text the returned index equals ``char_index``.
 
     Args:
         text: The string against which ``char_index`` is interpreted.
@@ -25,16 +27,14 @@ def get_utf16_index(text: str, char_index: int) -> int:
     Returns:
         The corresponding UTF-16 code unit offset.
     """
-    if char_index == 0:
-        return 0
-    prefix = text[:char_index]
-    # Count characters that need a surrogate pair (code point > 0xFFFF)
-    extra = sum(1 for ch in prefix if ord(ch) > 0xFFFF)
-    return char_index + extra
+    return len(text[:char_index].encode("utf-16-le")) // 2
 
 
 def get_utf8_index(text: str, char_index: int) -> int:
     """Convert a Python character (code point) index to a UTF-8 byte index.
+
+    ``char_index`` is interpreted like a Python slice bound: negative values
+    count from the end of ``text`` and out-of-range values are clamped.
 
     Args:
         text: The string against which ``char_index`` is interpreted.
@@ -43,8 +43,6 @@ def get_utf8_index(text: str, char_index: int) -> int:
     Returns:
         The corresponding UTF-8 byte offset.
     """
-    if char_index == 0:
-        return 0
     return len(text[:char_index].encode("utf-8"))
 
 

--- a/python/pycrdt/_text.py
+++ b/python/pycrdt/_text.py
@@ -174,12 +174,12 @@ class Text(Sequence):
         """
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
-            current = str(self)
-            offset = _char_to_offset(current, len(current), self.doc.offset_kind)
-            self.integrated.insert(txn._txn, offset, value)
+            # integrated.len is already in the doc's offset units, so the end
+            # offset is available without materializing the text
+            self.integrated.insert(txn._txn, self.integrated.len(txn._txn), value)
             return self
 
-    def _check_slice(self, key: slice) -> tuple[int, int]:
+    def _check_slice(self, length: int, key: slice) -> tuple[int, int]:
         if key.step is not None:
             raise RuntimeError("Step not supported")
         if key.start is None:
@@ -189,7 +189,7 @@ class Text(Sequence):
         else:
             start = key.start
         if key.stop is None:
-            stop = len(self)
+            stop = length
         elif key.stop < 0:
             raise RuntimeError("Negative stop not supported")
         else:
@@ -224,7 +224,7 @@ class Text(Sequence):
                 unit_len = _single_char_unit_len(current[key], ok)
                 self.integrated.remove_range(txn._txn, offset, unit_len)
             elif isinstance(key, slice):
-                start, stop = self._check_slice(key)
+                start, stop = self._check_slice(len(current), key)
                 if stop - start > 0:
                     offset_start = _char_to_offset(current, start, ok)
                     offset_stop = _char_to_offset(current, stop, ok)
@@ -280,7 +280,7 @@ class Text(Sequence):
                 self.integrated.remove_range(txn._txn, offset, unit_len)
                 self.integrated.insert(txn._txn, offset, value)
             elif isinstance(key, slice):
-                start, stop = self._check_slice(key)
+                start, stop = self._check_slice(len(current), key)
                 offset_start = _char_to_offset(current, start, ok)
                 offset_stop = _char_to_offset(current, stop, ok)
                 length = offset_stop - offset_start
@@ -344,8 +344,8 @@ class Text(Sequence):
         """
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
-            start, stop = self._check_slice(slice(start, stop))
             current = str(self)
+            start, stop = self._check_slice(len(current), slice(start, stop))
             ok = self.doc.offset_kind
             offset_start = _char_to_offset(current, start, ok)
             offset_stop = _char_to_offset(current, stop, ok)

--- a/python/pycrdt/_text.py
+++ b/python/pycrdt/_text.py
@@ -218,16 +218,16 @@ class Text(Sequence):
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
             current = str(self)
-            ok = self.doc.offset_kind
+            offset_kind = self.doc.offset_kind
             if isinstance(key, int):
-                offset = _char_to_offset(current, key, ok)
-                unit_len = _single_char_unit_len(current[key], ok)
+                offset = _char_to_offset(current, key, offset_kind)
+                unit_len = _single_char_unit_len(current[key], offset_kind)
                 self.integrated.remove_range(txn._txn, offset, unit_len)
             elif isinstance(key, slice):
                 start, stop = self._check_slice(len(current), key)
                 if stop - start > 0:
-                    offset_start = _char_to_offset(current, start, ok)
-                    offset_stop = _char_to_offset(current, stop, ok)
+                    offset_start = _char_to_offset(current, start, offset_kind)
+                    offset_stop = _char_to_offset(current, stop, offset_kind)
                     self.integrated.remove_range(txn._txn, offset_start, offset_stop - offset_start)
             else:
                 raise RuntimeError(f"Index not supported: {key}")
@@ -268,21 +268,21 @@ class Text(Sequence):
         with self.doc.transaction() as txn:
             self._forbid_read_transaction(txn)
             current = str(self)
-            ok = self.doc.offset_kind
+            offset_kind = self.doc.offset_kind
             if isinstance(key, int):
                 value_len = len(value)
                 if value_len != 1:
                     raise RuntimeError(
                         f"Single item assigned value must have a length of 1, not {value_len}"
                     )
-                offset = _char_to_offset(current, key, ok)
-                unit_len = _single_char_unit_len(current[key], ok)
+                offset = _char_to_offset(current, key, offset_kind)
+                unit_len = _single_char_unit_len(current[key], offset_kind)
                 self.integrated.remove_range(txn._txn, offset, unit_len)
                 self.integrated.insert(txn._txn, offset, value)
             elif isinstance(key, slice):
                 start, stop = self._check_slice(len(current), key)
-                offset_start = _char_to_offset(current, start, ok)
-                offset_stop = _char_to_offset(current, stop, ok)
+                offset_start = _char_to_offset(current, start, offset_kind)
+                offset_stop = _char_to_offset(current, stop, offset_kind)
                 length = offset_stop - offset_start
                 if length > 0:
                     self.integrated.remove_range(txn._txn, offset_start, length)
@@ -346,9 +346,9 @@ class Text(Sequence):
             self._forbid_read_transaction(txn)
             current = str(self)
             start, stop = self._check_slice(len(current), slice(start, stop))
-            ok = self.doc.offset_kind
-            offset_start = _char_to_offset(current, start, ok)
-            offset_stop = _char_to_offset(current, stop, ok)
+            offset_kind = self.doc.offset_kind
+            offset_start = _char_to_offset(current, start, offset_kind)
+            offset_stop = _char_to_offset(current, stop, offset_kind)
             length = offset_stop - offset_start
             if length > 0:
                 self.integrated.format(txn._txn, offset_start, length, iter(attrs.items()))

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -3,7 +3,7 @@ use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::types::{PyBool, PyBytes, PyDict, PyInt, PyList};
 use yrs::{
-    Doc as _Doc, Options, ReadTxn, StateVector, SubdocsEvent as _SubdocsEvent, Transact, TransactionCleanupEvent, TransactionMut, Update, WriteTxn
+    Doc as _Doc, OffsetKind, Options, ReadTxn, StateVector, SubdocsEvent as _SubdocsEvent, Transact, TransactionCleanupEvent, TransactionMut, Update, WriteTxn
 };
 use yrs::updates::encoder::{Encode, Encoder};
 use yrs::updates::decoder::Decode;
@@ -32,6 +32,7 @@ impl Doc {
         let mut options = yrs::Options::default();
         options.client_id = original.doc.client_id();
         options.skip_gc = original.doc.skip_gc();
+        options.offset_kind = OffsetKind::Utf16;
         if let Some(collection_id) = original.doc.collection_id() {
             options.collection_id = Some(collection_id);
         }
@@ -84,6 +85,11 @@ impl Doc {
                 .map_err(|_| PyValueError::new_err("skip_gc must be a valid bool"))?;
             options.skip_gc = _skip_gc;
         }
+        // Use UTF-16 offsets for compatibility with JS yjs clients.
+        // Without this, pycrdt uses UTF-8 byte offsets which causes
+        // findIndexSS crashes when JS yjs applies incremental updates
+        // containing multi-byte characters.
+        options.offset_kind = OffsetKind::Utf16;
         let doc = _Doc::with_options(options);
         Ok(Doc { doc })
     }

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -32,7 +32,7 @@ impl Doc {
         let mut options = yrs::Options::default();
         options.client_id = original.doc.client_id();
         options.skip_gc = original.doc.skip_gc();
-        options.offset_kind = OffsetKind::Utf16;
+        options.offset_kind = original.doc.offset_kind();
         if let Some(collection_id) = original.doc.collection_id() {
             options.collection_id = Some(collection_id);
         }
@@ -69,7 +69,11 @@ impl Doc {
 #[pymethods]
 impl Doc {
     #[new]
-    fn new(client_id: &Bound<'_, PyAny>, skip_gc: &Bound<'_, PyAny>) -> PyResult<Self> {
+    fn new(
+        client_id: &Bound<'_, PyAny>,
+        skip_gc: &Bound<'_, PyAny>,
+        offset_kind: &Bound<'_, PyAny>,
+    ) -> PyResult<Self> {
         let mut options = Options::default();
         if !client_id.is_none() {
             let _client_id: u64 = client_id.cast::<PyInt>()
@@ -85,13 +89,28 @@ impl Doc {
                 .map_err(|_| PyValueError::new_err("skip_gc must be a valid bool"))?;
             options.skip_gc = _skip_gc;
         }
-        // Use UTF-16 offsets for compatibility with JS yjs clients.
-        // Without this, pycrdt uses UTF-8 byte offsets which causes
-        // findIndexSS crashes when JS yjs applies incremental updates
-        // containing multi-byte characters.
-        options.offset_kind = OffsetKind::Utf16;
+        if !offset_kind.is_none() {
+            let _offset_kind: String = offset_kind
+                .extract()
+                .map_err(|_| PyValueError::new_err("offset_kind must be a string"))?;
+            options.offset_kind = match _offset_kind.as_str() {
+                "utf8" | "utf-8" => OffsetKind::Bytes,
+                "utf16" | "utf-16" => OffsetKind::Utf16,
+                _ => return Err(PyValueError::new_err(
+                    "offset_kind must be 'utf8' or 'utf16'",
+                )),
+            };
+        }
         let doc = _Doc::with_options(options);
         Ok(Doc { doc })
+    }
+
+    #[getter]
+    fn offset_kind(&self) -> &'static str {
+        match self.doc.offset_kind() {
+            OffsetKind::Bytes => "utf8",
+            OffsetKind::Utf16 => "utf16",
+        }
     }
 
     #[staticmethod]

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -97,8 +97,8 @@ impl Doc {
                 .extract()
                 .map_err(|_| PyValueError::new_err("offset_kind must be a string"))?;
             options.offset_kind = match _offset_kind.as_str() {
-                "utf8" | "utf-8" => OffsetKind::Bytes,
-                "utf16" | "utf-16" => OffsetKind::Utf16,
+                "utf8" => OffsetKind::Bytes,
+                "utf16" => OffsetKind::Utf16,
                 _ => return Err(PyValueError::new_err(
                     "offset_kind must be 'utf8' or 'utf16'",
                 )),

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -4,7 +4,6 @@ import pytest
 from anyio import TASK_STATUS_IGNORED, Event, create_task_group
 from anyio.abc import TaskStatus
 from pycrdt import Array, Assoc, Doc, Map, StickyIndex, Text
-from pycrdt._text import _char_to_utf16
 
 pytestmark = pytest.mark.anyio
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -4,7 +4,7 @@ import pytest
 from anyio import TASK_STATUS_IGNORED, Event, create_task_group
 from anyio.abc import TaskStatus
 from pycrdt import Array, Assoc, Doc, Map, StickyIndex, Text
-from pycrdt._text import _char_to_utf16, _utf16_to_char
+from pycrdt._text import _char_to_utf16
 
 pytestmark = pytest.mark.anyio
 
@@ -259,6 +259,17 @@ def test_unicode_emoji_sequential_inserts():
     assert str(text) == expected, f"Got {str(text)!r}"
 
 
+def test_unicode_emoji_iadd():
+    """`+=` after emoji should append at the end (regression for UTF-16 offset bug)."""
+    doc = Doc()
+    doc["text"] = text = Text()
+
+    text += "A📊B"
+    text += "X"
+
+    assert str(text) == "A📊BX"
+
+
 def test_unicode_emoji_len():
     """len() should return Python character count, not byte count."""
     doc = Doc()
@@ -497,62 +508,6 @@ def test_unicode_granular_diff(initial, updated):
 
     _apply_diff(text, initial, updated)
     assert str(text) == updated, f"Got {str(text)!r}, expected {updated!r}"
-
-
-def test_utf16_to_char_ascii():
-    """_utf16_to_char is identity for pure ASCII text."""
-    text = "Hello, World!"
-    for i in range(len(text) + 1):
-        assert _utf16_to_char(text, i) == i
-
-
-def test_utf16_to_char_bmp():
-    """BMP characters (CJK, Cyrillic) are 1 UTF-16 code unit each."""
-    text = "价格分析"  # 4 BMP CJK chars = 4 UTF-16 code units
-    assert _utf16_to_char(text, 0) == 0
-    assert _utf16_to_char(text, 1) == 1
-    assert _utf16_to_char(text, 2) == 2
-    assert _utf16_to_char(text, 4) == 4
-
-
-def test_utf16_to_char_supplementary():
-    """Supplementary plane chars (emoji) take 2 UTF-16 code units."""
-    text = "A📊B"  # UTF-16: A(1) 📊(2) B(1) = 4 code units, 3 chars
-    assert _utf16_to_char(text, 0) == 0  # before A
-    assert _utf16_to_char(text, 1) == 1  # before 📊
-    assert _utf16_to_char(text, 3) == 2  # before B (1 + 2 = 3)
-    assert _utf16_to_char(text, 4) == 3  # end
-
-
-def test_utf16_to_char_multiple_emoji():
-    """Multiple supplementary plane characters."""
-    text = "A📊B🎉C"  # UTF-16: A(1) 📊(2) B(1) 🎉(2) C(1) = 7 units, 5 chars
-    assert _utf16_to_char(text, 0) == 0  # before A
-    assert _utf16_to_char(text, 1) == 1  # before 📊
-    assert _utf16_to_char(text, 3) == 2  # before B
-    assert _utf16_to_char(text, 4) == 3  # before 🎉
-    assert _utf16_to_char(text, 6) == 4  # before C
-    assert _utf16_to_char(text, 7) == 5  # end
-
-
-def test_utf16_to_char_roundtrip():
-    """_char_to_utf16 and _utf16_to_char are inverses."""
-    texts = [
-        "Hello",
-        "A📊B",
-        "价格分析",
-        "# Analysis 📊\n",
-        "A𝒜B𠀀C",
-        "Hello 世界 📊 мир!",
-        "🎉📊🔒",
-    ]
-    for text in texts:
-        for char_idx in range(len(text) + 1):
-            utf16_idx = _char_to_utf16(text, char_idx)
-            assert _utf16_to_char(text, utf16_idx) == char_idx, (
-                f"Roundtrip failed for {text!r} at char_idx={char_idx}: "
-                f"utf16={utf16_idx}, back={_utf16_to_char(text, utf16_idx)}"
-            )
 
 
 def test_sticky_index_transaction():

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -581,8 +581,7 @@ def test_offset_kind_snapshot_round_trip(offset_kind):
     snap = Snapshot.from_doc(doc)
     restored = Doc.from_snapshot(snap, doc)
     assert restored.offset_kind == offset_kind, (
-        f"snapshot lost offset_kind: expected {offset_kind}, "
-        f"got {restored.offset_kind}"
+        f"snapshot lost offset_kind: expected {offset_kind}, got {restored.offset_kind}"
     )
     assert str(restored["text"]) == "A📊B"
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,3 +1,5 @@
+from difflib import SequenceMatcher
+
 import pytest
 from anyio import TASK_STATUS_IGNORED, Event, create_task_group
 from anyio.abc import TaskStatus
@@ -387,7 +389,6 @@ def test_unicode_cross_doc_sync():
 # initial content, then applies a granular edit (using SequenceMatcher on
 # byte offsets, matching how jupyter_ydoc.YUnicode.set() works), and verifies
 # the result is correct.
-from difflib import SequenceMatcher
 
 
 def _apply_diff(text, old_value, new_value):

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -3,7 +3,16 @@ from difflib import SequenceMatcher
 import pytest
 from anyio import TASK_STATUS_IGNORED, Event, create_task_group
 from anyio.abc import TaskStatus
-from pycrdt import Array, Assoc, Doc, Map, StickyIndex, Text
+from pycrdt import (
+    Array,
+    Assoc,
+    Doc,
+    Map,
+    StickyIndex,
+    Text,
+    get_utf8_index,
+    get_utf16_index,
+)
 
 pytestmark = pytest.mark.anyio
 
@@ -230,9 +239,14 @@ def test_sticky_index(serialize: str):
     assert text1[new_idx] == "*"
 
 
-def test_unicode_emoji_insert():
-    """Text.insert() after emoji characters should use character positions, not byte offsets."""
-    doc = Doc()
+@pytest.fixture(params=["utf8", "utf16"])
+def offset_kind(request):
+    return request.param
+
+
+def test_unicode_emoji_insert(offset_kind):
+    """Text.insert() after emoji characters should use character positions."""
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text()
 
     text += "A📊B"
@@ -244,9 +258,9 @@ def test_unicode_emoji_insert():
     assert str(text) == "A📊XB", f"Got {str(text)!r}, emoji insert position is wrong"
 
 
-def test_unicode_emoji_sequential_inserts():
+def test_unicode_emoji_sequential_inserts(offset_kind):
     """Sequential inserts after emoji should maintain correct positions."""
-    doc = Doc()
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text()
 
     text += "# Analysis 📊\n"
@@ -258,9 +272,11 @@ def test_unicode_emoji_sequential_inserts():
     assert str(text) == expected, f"Got {str(text)!r}"
 
 
-def test_unicode_emoji_iadd():
-    """`+=` after emoji should append at the end (regression for UTF-16 offset bug)."""
-    doc = Doc()
+def test_unicode_emoji_iadd(offset_kind):
+    """`+=` after emoji should append at the end (regression for the original
+    Text.__iadd__ bug where len(self) was passed to yrs as if it were already
+    in offset units)."""
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text()
 
     text += "A📊B"
@@ -269,66 +285,66 @@ def test_unicode_emoji_iadd():
     assert str(text) == "A📊BX"
 
 
-def test_unicode_emoji_len():
-    """len() should return Python character count, not byte count."""
-    doc = Doc()
+def test_unicode_emoji_len(offset_kind):
+    """len() should return Python character count, regardless of offset_kind."""
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text()
 
     text += "A📊B"
-    assert len(text) == 3  # 3 chars, not 6 bytes or 4 UTF-16 code units
+    assert len(text) == 3
 
     text += "🎉"
     assert len(text) == 4
 
 
-def test_unicode_emoji_delete():
+def test_unicode_emoji_delete(offset_kind):
     """Deleting a character after an emoji should work correctly."""
-    doc = Doc()
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text("A📊BC")
 
     del text[2]  # delete B (after emoji)
     assert str(text) == "A📊C", f"Got {str(text)!r}"
 
 
-def test_unicode_emoji_delete_emoji():
+def test_unicode_emoji_delete_emoji(offset_kind):
     """Deleting an emoji character itself should work correctly."""
-    doc = Doc()
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text("A📊B")
 
     del text[1]  # delete 📊
     assert str(text) == "AB", f"Got {str(text)!r}"
 
 
-def test_unicode_emoji_slice_delete():
+def test_unicode_emoji_slice_delete(offset_kind):
     """Slice deletion across emoji boundaries should work correctly."""
-    doc = Doc()
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text("A📊B🎉C")
 
     del text[1:4]  # delete 📊B🎉
     assert str(text) == "AC", f"Got {str(text)!r}"
 
 
-def test_unicode_emoji_setitem():
+def test_unicode_emoji_setitem(offset_kind):
     """Replacing a character after an emoji should work correctly."""
-    doc = Doc()
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text("A📊BC")
 
     text[2] = "X"  # replace B (after emoji)
     assert str(text) == "A📊XC", f"Got {str(text)!r}"
 
 
-def test_unicode_emoji_slice_setitem():
+def test_unicode_emoji_slice_setitem(offset_kind):
     """Slice replacement spanning emoji should work correctly."""
-    doc = Doc()
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text("A📊B🎉C")
 
     text[1:4] = "XYZ"  # replace 📊B🎉 with XYZ
     assert str(text) == "AXYZC", f"Got {str(text)!r}"
 
 
-def test_unicode_cjk():
-    """CJK characters (BMP, 1 UTF-16 code unit each) should work correctly."""
-    doc = Doc()
+def test_unicode_cjk(offset_kind):
+    """CJK characters (BMP, 1 UTF-16 code unit but 3 UTF-8 bytes each)."""
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text()
 
     text += "价格"
@@ -337,9 +353,9 @@ def test_unicode_cjk():
     assert len(text) == 3
 
 
-def test_unicode_mixed_scripts():
+def test_unicode_mixed_scripts(offset_kind):
     """Mixed ASCII, CJK, Cyrillic, and emoji in one text."""
-    doc = Doc()
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text()
 
     text += "Hello"
@@ -353,9 +369,9 @@ def test_unicode_mixed_scripts():
     assert len(text) == 15
 
 
-def test_unicode_supplementary_plane():
-    """Characters outside BMP (require UTF-16 surrogate pairs)."""
-    doc = Doc()
+def test_unicode_supplementary_plane(offset_kind):
+    """Characters outside BMP."""
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text()
 
     # 𝒜 (U+1D49C) = Mathematical Script Capital A
@@ -370,9 +386,14 @@ def test_unicode_supplementary_plane():
     assert str(text) == "A𝒜XB𠀀YC", f"Got {str(text)!r}"
 
 
-def test_unicode_cross_doc_sync():
-    """Updates with Unicode content should sync correctly between two pycrdt docs."""
-    doc1 = Doc()
+def test_unicode_cross_doc_sync(offset_kind):
+    """Updates with Unicode content should sync correctly between two pycrdt docs.
+
+    Both docs must use the same offset_kind — peers with mismatched offset
+    kinds is a known incompatibility (yrs and yjs both require all peers in
+    a swarm to agree).
+    """
+    doc1 = Doc(offset_kind=offset_kind)
     doc1["text"] = text1 = Text()
 
     # Capture updates from doc1
@@ -384,7 +405,7 @@ def test_unicode_cross_doc_sync():
     text1.insert(len(text1), "# 特征工程\n")
 
     # Apply to doc2
-    doc2 = Doc()
+    doc2 = Doc(offset_kind=offset_kind)
     doc2["text"] = Text()
     for update in updates:
         doc2.apply_update(update)
@@ -494,12 +515,12 @@ def _apply_diff(text, old_value, new_value):
         "math_operators",
     ],
 )
-def test_unicode_granular_diff(initial, updated):
+def test_unicode_granular_diff(initial, updated, offset_kind):
     """Granular text edits with multi-byte Unicode should produce correct results.
 
     Test cases adapted from jupyter-server/jupyter_ydoc#370.
     """
-    doc = Doc()
+    doc = Doc(offset_kind=offset_kind)
     doc["text"] = text = Text()
 
     text += initial
@@ -507,6 +528,63 @@ def test_unicode_granular_diff(initial, updated):
 
     _apply_diff(text, initial, updated)
     assert str(text) == updated, f"Got {str(text)!r}, expected {updated!r}"
+
+
+def test_get_utf16_index():
+    # ASCII: identity
+    assert get_utf16_index("hello", 0) == 0
+    assert get_utf16_index("hello", 5) == 5
+    # BMP CJK: 1 code point = 1 UTF-16 code unit
+    assert get_utf16_index("价格", 2) == 2
+    # Non-BMP emoji: 1 code point = 2 UTF-16 code units (surrogate pair)
+    assert get_utf16_index("A📊B", 1) == 1
+    assert get_utf16_index("A📊B", 2) == 3
+    assert get_utf16_index("A📊B", 3) == 4
+
+
+def test_get_utf8_index():
+    # ASCII: identity
+    assert get_utf8_index("hello", 0) == 0
+    assert get_utf8_index("hello", 5) == 5
+    # BMP CJK: 1 code point = 3 UTF-8 bytes
+    assert get_utf8_index("价格", 1) == 3
+    assert get_utf8_index("价格", 2) == 6
+    # Non-BMP emoji: 1 code point = 4 UTF-8 bytes
+    assert get_utf8_index("A📊B", 1) == 1
+    assert get_utf8_index("A📊B", 2) == 5
+    assert get_utf8_index("A📊B", 3) == 6
+
+
+def test_offset_kind_default_is_utf8():
+    assert Doc().offset_kind == "utf8"
+
+
+def test_offset_kind_explicit():
+    assert Doc(offset_kind="utf8").offset_kind == "utf8"
+    assert Doc(offset_kind="utf16").offset_kind == "utf16"
+    # hyphenated forms accepted
+    assert Doc(offset_kind="utf-8").offset_kind == "utf8"
+    assert Doc(offset_kind="utf-16").offset_kind == "utf16"
+
+
+def test_offset_kind_invalid_raises():
+    with pytest.raises(ValueError):
+        Doc(offset_kind="utf32")
+
+
+def test_offset_kind_snapshot_round_trip(offset_kind):
+    """from_snapshot must preserve the source doc's offset_kind."""
+    from pycrdt import Snapshot
+
+    doc = Doc(offset_kind=offset_kind, skip_gc=True)
+    doc["text"] = Text("A📊B")
+    snap = Snapshot.from_doc(doc)
+    restored = Doc.from_snapshot(snap, doc)
+    assert restored.offset_kind == offset_kind, (
+        f"snapshot lost offset_kind: expected {offset_kind}, "
+        f"got {restored.offset_kind}"
+    )
+    assert str(restored["text"]) == "A📊B"
 
 
 def test_sticky_index_transaction():

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -228,6 +228,159 @@ def test_sticky_index(serialize: str):
     assert text1[new_idx] == "*"
 
 
+def test_unicode_emoji_insert():
+    """Text.insert() after emoji characters should use character positions, not byte offsets."""
+    doc = Doc()
+    doc["text"] = text = Text()
+
+    text += "A📊B"
+    assert str(text) == "A📊B"
+    assert len(text) == 3
+
+    # Insert at position 2 = between 📊 and B
+    text.insert(2, "X")
+    assert str(text) == "A📊XB", f"Got {str(text)!r}, emoji insert position is wrong"
+
+
+def test_unicode_emoji_sequential_inserts():
+    """Sequential inserts after emoji should maintain correct positions."""
+    doc = Doc()
+    doc["text"] = text = Text()
+
+    text += "# Analysis 📊\n"
+    text.insert(len(text), "model = fit()\n")
+    text.insert(len(text), "# 特征工程\n")
+    text.insert(len(text), 'print("done")\n')
+
+    expected = '# Analysis 📊\nmodel = fit()\n# 特征工程\nprint("done")\n'
+    assert str(text) == expected, f"Got {str(text)!r}"
+
+
+def test_unicode_emoji_len():
+    """len() should return Python character count, not byte count."""
+    doc = Doc()
+    doc["text"] = text = Text()
+
+    text += "A📊B"
+    assert len(text) == 3  # 3 chars, not 6 bytes or 4 UTF-16 code units
+
+    text += "🎉"
+    assert len(text) == 4
+
+
+def test_unicode_emoji_delete():
+    """Deleting a character after an emoji should work correctly."""
+    doc = Doc()
+    doc["text"] = text = Text("A📊BC")
+
+    del text[2]  # delete B (after emoji)
+    assert str(text) == "A📊C", f"Got {str(text)!r}"
+
+
+def test_unicode_emoji_delete_emoji():
+    """Deleting an emoji character itself should work correctly."""
+    doc = Doc()
+    doc["text"] = text = Text("A📊B")
+
+    del text[1]  # delete 📊
+    assert str(text) == "AB", f"Got {str(text)!r}"
+
+
+def test_unicode_emoji_slice_delete():
+    """Slice deletion across emoji boundaries should work correctly."""
+    doc = Doc()
+    doc["text"] = text = Text("A📊B🎉C")
+
+    del text[1:4]  # delete 📊B🎉
+    assert str(text) == "AC", f"Got {str(text)!r}"
+
+
+def test_unicode_emoji_setitem():
+    """Replacing a character after an emoji should work correctly."""
+    doc = Doc()
+    doc["text"] = text = Text("A📊BC")
+
+    text[2] = "X"  # replace B (after emoji)
+    assert str(text) == "A📊XC", f"Got {str(text)!r}"
+
+
+def test_unicode_emoji_slice_setitem():
+    """Slice replacement spanning emoji should work correctly."""
+    doc = Doc()
+    doc["text"] = text = Text("A📊B🎉C")
+
+    text[1:4] = "XYZ"  # replace 📊B🎉 with XYZ
+    assert str(text) == "AXYZC", f"Got {str(text)!r}"
+
+
+def test_unicode_cjk():
+    """CJK characters (BMP, 1 UTF-16 code unit each) should work correctly."""
+    doc = Doc()
+    doc["text"] = text = Text()
+
+    text += "价格"
+    text.insert(2, "X")
+    assert str(text) == "价格X", f"Got {str(text)!r}"
+    assert len(text) == 3
+
+
+def test_unicode_mixed_scripts():
+    """Mixed ASCII, CJK, Cyrillic, and emoji in one text."""
+    doc = Doc()
+    doc["text"] = text = Text()
+
+    text += "Hello"
+    text.insert(5, " 世界")
+    text.insert(8, " 📊")
+    text.insert(11, " мир")
+    text.insert(15, "!")
+
+    expected = "Hello 世界 📊 мир!"
+    assert str(text) == expected, f"Got {str(text)!r}"
+    assert len(text) == 15
+
+
+def test_unicode_supplementary_plane():
+    """Characters outside BMP (require UTF-16 surrogate pairs)."""
+    doc = Doc()
+    doc["text"] = text = Text()
+
+    # 𝒜 (U+1D49C) = Mathematical Script Capital A
+    # 𠀀 (U+20000) = CJK Unified Ideograph Extension B
+    text += "A𝒜B𠀀C"
+    assert len(text) == 5
+
+    text.insert(2, "X")  # between 𝒜 and B
+    assert str(text) == "A𝒜XB𠀀C", f"Got {str(text)!r}"
+
+    text.insert(5, "Y")  # between 𠀀 and C
+    assert str(text) == "A𝒜XB𠀀YC", f"Got {str(text)!r}"
+
+
+def test_unicode_cross_doc_sync():
+    """Updates with Unicode content should sync correctly between two pycrdt docs."""
+    doc1 = Doc()
+    doc1["text"] = text1 = Text()
+
+    # Capture updates from doc1
+    updates = []
+    doc1.observe(lambda event: updates.append(event.update))
+
+    text1 += "# Analysis 📊\n"
+    text1.insert(len(text1), "model = fit()\n")
+    text1.insert(len(text1), "# 特征工程\n")
+
+    # Apply to doc2
+    doc2 = Doc()
+    doc2["text"] = Text()
+    for update in updates:
+        doc2.apply_update(update)
+
+    assert str(doc2["text"]) == str(text1), (
+        f"Docs diverged: doc1={str(text1)!r} doc2={str(doc2['text'])!r}"
+    )
+
+
 def test_sticky_index_transaction():
     doc = Doc()
     text = doc.get("text", type=Text)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -4,6 +4,7 @@ import pytest
 from anyio import TASK_STATUS_IGNORED, Event, create_task_group
 from anyio.abc import TaskStatus
 from pycrdt import Array, Assoc, Doc, Map, StickyIndex, Text
+from pycrdt._text import _char_to_utf16, _utf16_to_char
 
 pytestmark = pytest.mark.anyio
 
@@ -496,6 +497,62 @@ def test_unicode_granular_diff(initial, updated):
 
     _apply_diff(text, initial, updated)
     assert str(text) == updated, f"Got {str(text)!r}, expected {updated!r}"
+
+
+def test_utf16_to_char_ascii():
+    """_utf16_to_char is identity for pure ASCII text."""
+    text = "Hello, World!"
+    for i in range(len(text) + 1):
+        assert _utf16_to_char(text, i) == i
+
+
+def test_utf16_to_char_bmp():
+    """BMP characters (CJK, Cyrillic) are 1 UTF-16 code unit each."""
+    text = "价格分析"  # 4 BMP CJK chars = 4 UTF-16 code units
+    assert _utf16_to_char(text, 0) == 0
+    assert _utf16_to_char(text, 1) == 1
+    assert _utf16_to_char(text, 2) == 2
+    assert _utf16_to_char(text, 4) == 4
+
+
+def test_utf16_to_char_supplementary():
+    """Supplementary plane chars (emoji) take 2 UTF-16 code units."""
+    text = "A📊B"  # UTF-16: A(1) 📊(2) B(1) = 4 code units, 3 chars
+    assert _utf16_to_char(text, 0) == 0  # before A
+    assert _utf16_to_char(text, 1) == 1  # before 📊
+    assert _utf16_to_char(text, 3) == 2  # before B (1 + 2 = 3)
+    assert _utf16_to_char(text, 4) == 3  # end
+
+
+def test_utf16_to_char_multiple_emoji():
+    """Multiple supplementary plane characters."""
+    text = "A📊B🎉C"  # UTF-16: A(1) 📊(2) B(1) 🎉(2) C(1) = 7 units, 5 chars
+    assert _utf16_to_char(text, 0) == 0  # before A
+    assert _utf16_to_char(text, 1) == 1  # before 📊
+    assert _utf16_to_char(text, 3) == 2  # before B
+    assert _utf16_to_char(text, 4) == 3  # before 🎉
+    assert _utf16_to_char(text, 6) == 4  # before C
+    assert _utf16_to_char(text, 7) == 5  # end
+
+
+def test_utf16_to_char_roundtrip():
+    """_char_to_utf16 and _utf16_to_char are inverses."""
+    texts = [
+        "Hello",
+        "A📊B",
+        "价格分析",
+        "# Analysis 📊\n",
+        "A𝒜B𠀀C",
+        "Hello 世界 📊 мир!",
+        "🎉📊🔒",
+    ]
+    for text in texts:
+        for char_idx in range(len(text) + 1):
+            utf16_idx = _char_to_utf16(text, char_idx)
+            assert _utf16_to_char(text, utf16_idx) == char_idx, (
+                f"Roundtrip failed for {text!r} at char_idx={char_idx}: "
+                f"utf16={utf16_idx}, back={_utf16_to_char(text, utf16_idx)}"
+            )
 
 
 def test_sticky_index_transaction():

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -572,6 +572,13 @@ def test_offset_kind_invalid_raises():
         Doc(offset_kind="utf32")
 
 
+def test_offset_kind_doc_mismatch_raises():
+    """Doc(doc=existing, offset_kind=other) must reject conflicting values."""
+    utf8_doc = Doc(offset_kind="utf8")
+    with pytest.raises(ValueError, match="does not match"):
+        Doc(doc=utf8_doc._doc, offset_kind="utf16")
+
+
 def test_offset_kind_snapshot_round_trip(offset_kind):
     """from_snapshot must preserve the source doc's offset_kind."""
     from pycrdt import Snapshot

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -381,6 +381,122 @@ def test_unicode_cross_doc_sync():
     )
 
 
+# Test cases adapted from jupyter-server/jupyter_ydoc#370 (prior art for
+# the workaround at the jupyter_ydoc layer). These exercise pycrdt's Text
+# operations directly with the same Unicode edge cases. Each test sets
+# initial content, then applies a granular edit (using SequenceMatcher on
+# byte offsets, matching how jupyter_ydoc.YUnicode.set() works), and verifies
+# the result is correct.
+from difflib import SequenceMatcher
+
+
+def _apply_diff(text, old_value, new_value):
+    """Apply a granular diff from old_value to new_value using character-level
+    SequenceMatcher. With the UTF-16 offset fix, pycrdt Text indices are
+    character-based, so we diff on characters (not bytes)."""
+    matcher = SequenceMatcher(a=old_value, b=new_value)
+
+    offset = 0
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "replace":
+            text[i1 + offset : i2 + offset] = new_value[j1:j2]
+            offset += (j2 - j1) - (i2 - i1)
+        elif tag == "delete":
+            del text[i1 + offset : i2 + offset]
+            offset -= i2 - i1
+        elif tag == "insert":
+            text.insert(i1 + offset, new_value[j1:j2])
+            offset += j2 - j1
+
+
+@pytest.mark.parametrize(
+    "initial, updated",
+    [
+        # emojis swapped
+        (
+            "I like security 🎨 but I really love painting 🔒",
+            "I like security 🔒 but I really love painting 🎨",
+        ),
+        # text changes, emojis stay in place
+        (
+            "Here is a rocket: ⭐ and a star: 🚀",
+            "Here is a star: ⭐ and a rocket: 🚀",
+        ),
+        # change of text and emojis
+        (
+            "Here are some happy faces: 😀😁😂",
+            "Here are some sad faces: 😞😢😭",
+        ),
+        # change of characters with combining marks
+        (
+            "Combining characters: á é í ó ú",
+            "Combining characters: ú ó í é á",
+        ),
+        # flags (regional indicator sequences)
+        (
+            "Flags: 🇺🇸🇬🇧🇨🇦",
+            "Flags: 🇨🇦🇬🇧🇺🇸",
+        ),
+        # Zero-width joiner sequences (family emoji)
+        (
+            "A family 👨\u200d👩\u200d👧\u200d👦 (with two children)",
+            "A family 👨\u200d👩\u200d👧 (with one child)",
+        ),
+        # Mixed RTL/LTR text
+        (
+            "Hello שלום world",
+            "Hello עולם world",
+        ),
+        # Keycap sequences
+        (
+            "Numbers: 1️⃣2️⃣3️⃣",
+            "Numbers: 3️⃣2️⃣1️⃣",
+        ),
+        # Emoji at boundaries
+        (
+            "👋 middle text 🎉",
+            "🎉 middle text 👋",
+        ),
+        # Japanese characters
+        (
+            "こんにちは世界",
+            "こんにちは地球",
+        ),
+        # Julia math operators
+        (
+            "x ∈ [1, 2, 3] && y ≥ 0",
+            "x ∉ [1, 2, 3] || y ≤ 0",
+        ),
+    ],
+    ids=[
+        "emoji_swap",
+        "text_change_emoji_stay",
+        "emoji_change",
+        "combining_marks",
+        "flags",
+        "zwj_family",
+        "rtl_ltr",
+        "keycap",
+        "emoji_boundaries",
+        "japanese",
+        "math_operators",
+    ],
+)
+def test_unicode_granular_diff(initial, updated):
+    """Granular text edits with multi-byte Unicode should produce correct results.
+
+    Test cases adapted from jupyter-server/jupyter_ydoc#370.
+    """
+    doc = Doc()
+    doc["text"] = text = Text()
+
+    text += initial
+    assert str(text) == initial
+
+    _apply_diff(text, initial, updated)
+    assert str(text) == updated, f"Got {str(text)!r}, expected {updated!r}"
+
+
 def test_sticky_index_transaction():
     doc = Doc()
     text = doc.get("text", type=Text)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -543,6 +543,11 @@ def test_get_utf16_index():
     assert get_utf16_index("A📊B", 1) == 1
     assert get_utf16_index("A📊B", 2) == 3
     assert get_utf16_index("A📊B", 3) == 4
+    # Python slice-bound semantics: clamped when out of range, from the end
+    # when negative
+    assert get_utf16_index("A📊B", 100) == 4
+    assert get_utf16_index("A📊B", -1) == 3
+    assert get_utf16_index("A📊B", -100) == 0
 
 
 def test_get_utf8_index():
@@ -556,6 +561,49 @@ def test_get_utf8_index():
     assert get_utf8_index("A📊B", 1) == 1
     assert get_utf8_index("A📊B", 2) == 5
     assert get_utf8_index("A📊B", 3) == 6
+    # Python slice-bound semantics: clamped when out of range, from the end
+    # when negative
+    assert get_utf8_index("A📊B", 100) == 6
+    assert get_utf8_index("A📊B", -1) == 5
+    assert get_utf8_index("A📊B", -100) == 0
+
+
+def test_unicode_negative_index(offset_kind):
+    """Negative indices count from the end, identically in both offset kinds."""
+    doc = Doc(offset_kind=offset_kind)
+    doc["text"] = text = Text("A📊B")
+    del text[-1]
+    assert str(text) == "A📊"
+
+    doc["text2"] = text2 = Text("A📊B")
+    text2[-1] = "X"
+    assert str(text2) == "A📊X"
+
+    doc["text3"] = text3 = Text("A📊B")
+    text3.insert(-1, "X")
+    assert str(text3) == "A📊XB"
+
+
+def test_unicode_out_of_range_index(offset_kind):
+    """Out-of-range indices clamp like Python slices, identically in both
+    offset kinds (no panic, no partial mutation)."""
+    doc = Doc(offset_kind=offset_kind)
+    doc["text"] = text = Text("A📊B")
+    del text[1:100]
+    assert str(text) == "A"
+
+    doc["text2"] = text2 = Text("A📊B")
+    text2[1:100] = "Z"
+    assert str(text2) == "AZ"
+
+    doc["text3"] = text3 = Text("A📊B")
+    text3.insert(100, "X")
+    assert str(text3) == "A📊BX"
+
+    doc["text4"] = text4 = Text("A📊B")
+    with pytest.raises(IndexError):
+        del text4[5]
+    assert str(text4) == "A📊B"
 
 
 def test_offset_kind_default_is_utf8():

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -613,14 +613,13 @@ def test_offset_kind_default_is_utf8():
 def test_offset_kind_explicit():
     assert Doc(offset_kind="utf8").offset_kind == "utf8"
     assert Doc(offset_kind="utf16").offset_kind == "utf16"
-    # hyphenated forms accepted
-    assert Doc(offset_kind="utf-8").offset_kind == "utf8"
-    assert Doc(offset_kind="utf-16").offset_kind == "utf16"
 
 
 def test_offset_kind_invalid_raises():
     with pytest.raises(ValueError):
         Doc(offset_kind="utf32")
+    with pytest.raises(ValueError):
+        Doc(offset_kind="utf-16")
 
 
 def test_offset_kind_doc_mismatch_raises():
@@ -628,6 +627,13 @@ def test_offset_kind_doc_mismatch_raises():
     utf8_doc = Doc(offset_kind="utf8")
     with pytest.raises(ValueError, match="does not match"):
         Doc(doc=utf8_doc._doc, offset_kind="utf16")
+
+
+def test_offset_kind_doc_match_accepted(offset_kind):
+    """Doc(doc=existing, offset_kind=same) must be accepted."""
+    doc = Doc(offset_kind=offset_kind)
+    wrapped = Doc(doc=doc._doc, offset_kind=offset_kind)
+    assert wrapped.offset_kind == offset_kind
 
 
 def test_offset_kind_snapshot_round_trip(offset_kind):

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -389,14 +389,15 @@ def test_unicode_supplementary_plane(offset_kind):
     assert str(text) == "A𝒜XB𠀀YC", f"Got {str(text)!r}"
 
 
-def test_unicode_cross_doc_sync(offset_kind):
+@pytest.mark.parametrize("source_kind", ["utf8", "utf16"])
+def test_unicode_cross_doc_sync(source_kind, offset_kind):
     """Updates with Unicode content should sync correctly between two pycrdt docs.
 
-    Both docs must use the same offset_kind — peers with mismatched offset
-    kinds is a known incompatibility (yrs and yjs both require all peers in
-    a swarm to agree).
+    The offset kind is a per-document setting that only affects how indices
+    passed to the yrs API are interpreted; the update wire format is the same
+    for both kinds, so documents with different offset kinds stay in sync.
     """
-    doc1 = Doc(offset_kind=offset_kind)
+    doc1 = Doc(offset_kind=source_kind)
     doc1["text"] = text1 = Text()
 
     # Capture updates from doc1
@@ -421,9 +422,8 @@ def test_unicode_cross_doc_sync(offset_kind):
 # Test cases adapted from jupyter-server/jupyter_ydoc#370 (prior art for
 # the workaround at the jupyter_ydoc layer). These exercise pycrdt's Text
 # operations directly with the same Unicode edge cases. Each test sets
-# initial content, then applies a granular edit (using SequenceMatcher on
-# byte offsets, matching how jupyter_ydoc.YUnicode.set() works), and verifies
-# the result is correct.
+# initial content, then applies a granular edit via _apply_diff, and
+# verifies the result is correct.
 
 
 def _apply_diff(text, old_value, new_value):
@@ -463,10 +463,12 @@ def _apply_diff(text, old_value, new_value):
             "Here are some happy faces: 😀😁😂",
             "Here are some sad faces: 😞😢😭",
         ),
-        # change of characters with combining marks
+        # change of characters with combining marks (decomposed: base letter
+        # followed by U+0301 COMBINING ACUTE ACCENT, so SequenceMatcher
+        # opcodes can split a base character from its mark)
         (
-            "Combining characters: á é í ó ú",
-            "Combining characters: ú ó í é á",
+            "Combining characters: a\u0301 e\u0301 i\u0301 o\u0301 u\u0301",
+            "Combining characters: u\u0301 o\u0301 i\u0301 e\u0301 a\u0301",
         ),
         # flags (regional indicator sequences)
         (


### PR DESCRIPTION
## Summary

- Add `Doc(offset_kind="utf8" | "utf16")` (default `"utf8"`, the yrs default) controlling how yrs counts text positions internally
- Convert Python character (code point) indices to the doc's offset units in all `Text` mutation methods — `insert`, `insert_embed`, `__setitem__`, `__delitem__`, `format`, `__iadd__`
- `len(text)` now returns the Python character count
- Export `get_utf8_index` / `get_utf16_index` conversion helpers
- 30+ new Unicode tests (emoji, CJK, combining marks, ZWJ, surrogate pairs), parametrized over both offset kinds

## The bug

pycrdt passed Python character indices straight to yrs, which interprets them in the doc's offset units (UTF-8 bytes by default). Any index past a multi-byte character landed in the wrong place — or mid-character:

```python
doc = Doc()
doc['t'] = t = Text()
t += 'A📊B'
t.insert(2, 'X')   # before: 'A📊BX' (or a yrs panic) — after: 'A📊XB'
```

On `main`, the new test cases produce wrong results and `pyo3_runtime.PanicException` panics from yrs (see @dlqqq's run earlier in this thread). With the conversion in place, all operations are character-based in both offset kinds.

## What offset_kind does (and doesn't do)

Earlier revisions of this description claimed UTF-16 was required for yjs compatibility — @jbdyn was right to push on that, and it's now corrected. The update **wire format is identical for both kinds** (struct clocks are UTF-16 code units either way); the tests now sync docs across mismatched kinds to pin that down, and I've verified content round-trips against yjs 13.6.31 in both modes. `offset_kind` controls how *indices passed to yrs APIs* are interpreted. `"utf16"` matches JS yjs index semantics, which matters when raw yrs offsets cross runtimes — sticky indices (#382) and event delta units (discussed above).

## Heads-up for release planning

Making indices character-based is a behavior change for callers that pre-converted to byte offsets as a #308 workaround — jupyter_ydoc's `YUnicode.set()` (jupyter-server/jupyter_ydoc#370) is a released example and would corrupt against this change. Since jupyter_ydoc pins `pycrdt >=0.14,<0.15`, shipping this as 0.15.0 with a coordinated jupyter_ydoc update (drop the byte-diff workaround when pycrdt >= 0.15) avoids any window where both fixes are active. Happy to open that jupyter_ydoc PR.

## Index semantics

Indices follow Python conventions in both offset kinds: out-of-range slice bounds clamp (`del t[1:100]` ≡ `del t[1:]`), negative indices count from the end. Note negative int keys previously raised `OverflowError` on `main`; they now resolve Python-style, matching `__getitem__`. If you'd rather keep rejecting them I can do that instead — the important property is that both offset kinds behave identically, which is now tested.

Follow-ups already split out: #381 (`XmlText`, stacked on this), #382 (`StickyIndex`), `TextEvent.delta` units (flagged in-thread for discussion).

Fixes #308
Related: jupyter-ai-contrib/jupyter-server-documents#197
