### PR TITLE
feat: add optional guid parameter to Doc constructor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ name = "pycrdt"
 crate-type = ["cdylib"]
 
 [dependencies]
-futures-task = "0.3.33"
+futures-task = "0.3.34"
 serde = "1.0.229"
 serde_json = "1.0.151"
 yrs = "0.27.3"
-pyo3 = "0.29.0"
+pyo3 = "0.29.2"

--- a/python/pycrdt/_base.py
+++ b/python/pycrdt/_base.py
@@ -61,6 +61,7 @@ class BaseDoc:
         *,
         client_id: int | None = None,
         skip_gc: bool | None = None,
+        guid: str | None = None,
         doc: _Doc | None = None,
         Model=None,
         allow_multithreading: bool = False,
@@ -68,7 +69,7 @@ class BaseDoc:
     ) -> None:
         super().__init__(**data)
         if doc is None:
-            doc = _Doc(client_id, skip_gc)
+            doc = _Doc(client_id, skip_gc, guid)
         self._doc = doc
         self._txn = None
         self._exceptions = []

--- a/python/pycrdt/_doc.py
+++ b/python/pycrdt/_doc.py
@@ -55,6 +55,7 @@ class Doc(BaseDoc, Generic[T]):
         *,
         client_id: int | None = None,
         skip_gc: bool | None = None,
+        guid: str | None = None,
         doc: _Doc | None = None,
         Model=None,
         allow_multithreading: bool = False,
@@ -65,11 +66,13 @@ class Doc(BaseDoc, Generic[T]):
             client_id: An optional client ID for the document.
             skip_gc: Whether to skip garbage collection on deleted collections
                 on transaction commit.
+            guid: An optional globally unique identifier for the document.
             allow_multithreading: Whether to allow the document to be used in different threads.
         """
         super().__init__(
             client_id=client_id,
             skip_gc=skip_gc,
+            guid=guid,
             doc=doc,
             Model=Model,
             allow_multithreading=allow_multithreading,
@@ -84,7 +87,7 @@ class Doc(BaseDoc, Generic[T]):
         self._event_subscription: dict[bool, Subscription] = {}
 
     @property
-    def guid(self) -> int:
+    def guid(self) -> str:
         """The GUID of the document."""
         return self._doc.guid()
 

--- a/python/pycrdt/_pycrdt.pyi
+++ b/python/pycrdt/_pycrdt.pyi
@@ -17,7 +17,7 @@ class Snapshot:
 class Doc:
     """Shared document."""
 
-    def __init__(self, client_id: int | None, skip_gc: bool | None) -> None:
+    def __init__(self, client_id: int | None, skip_gc: bool | None, guid: str | None) -> None:
         """Create a new document with an optional global client ID.
         If no client ID is passed, a random one will be generated."""
 
@@ -28,7 +28,7 @@ class Doc:
     def client_id(self) -> int:
         """Returns the document unique client identifier."""
 
-    def guid(self) -> int:
+    def guid(self) -> str:
         """Returns the document globally unique identifier."""
 
     def create_transaction(self) -> Transaction:

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -1,7 +1,8 @@
 use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
-use pyo3::types::{PyBool, PyBytes, PyDict, PyInt, PyList};
+use pyo3::types::{PyBool, PyBytes, PyDict, PyInt, PyList, PyString};
+use std::sync::Arc;
 use yrs::{
     ClientID, Doc as _Doc, Options, ReadTxn, StateVector, SubdocsEvent as _SubdocsEvent, Transact, TransactionCleanupEvent, TransactionMut, Update, WriteTxn
 };
@@ -68,7 +69,11 @@ impl Doc {
 #[pymethods]
 impl Doc {
     #[new]
-    fn new(client_id: &Bound<'_, PyAny>, skip_gc: &Bound<'_, PyAny>) -> PyResult<Self> {
+    fn new(
+        client_id: &Bound<'_, PyAny>,
+        skip_gc: &Bound<'_, PyAny>,
+        guid: &Bound<'_, PyAny>,
+    ) -> PyResult<Self> {
         let mut options = Options::default();
         if !client_id.is_none() {
             let _client_id: u64 = client_id.cast::<PyInt>()
@@ -86,6 +91,14 @@ impl Doc {
                 .extract()
                 .map_err(|_| PyValueError::new_err("skip_gc must be a valid bool"))?;
             options.skip_gc = _skip_gc;
+        }
+        if !guid.is_none() {
+            let guid: String = guid
+                .cast::<PyString>()
+                .map_err(|_| PyValueError::new_err("guid must be a string"))?
+                .extract()
+                .map_err(|_| PyValueError::new_err("guid must be a valid string"))?;
+            options.guid = Arc::<str>::from(guid);
         }
         let doc = _Doc::with_options(options);
         Ok(Doc { doc })

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -175,6 +175,16 @@ def test_client_id():
     assert update[2 : 2 + len(b)] == b
 
 
+def test_guid():
+    guid = "my-document"
+    assert Doc(guid=guid).guid == guid
+
+
+def test_invalid_guid():
+    with pytest.raises(ValueError, match="guid must be a string"):
+        Doc(guid=1)  # type: ignore[arg-type]
+
+
 def test_roots():
     remote_doc = Doc(
         {


### PR DESCRIPTION
## Summary

Add support for an optional `guid` parameter when creating a `Doc`.

- Forward `guid` through the Python and Rust constructors to `yrs::Options.guid`.
- Preserve the existing random GUID behavior when `guid` is omitted.
- Validate that a supplied GUID is a string.
- Correct the `Doc.guid` return type annotation to `str`.

## Testing

- `pytest -q tests`
- `mypy python`