### PR TITLE
Free unsendable events on the emitting thread

### DIFF
--- a/python/pycrdt/_base.py
+++ b/python/pycrdt/_base.py
@@ -306,6 +306,7 @@ def observe_callback(
 ):
     with doc._read_transaction(event.transaction) as txn:
         _event = event_types[type(event)](event, doc)
+        del event
         _event.transaction = txn
         params = (_event, txn)
         try:
@@ -325,6 +326,7 @@ def observe_deep_callback(
             _event = event_types[type(event)](event, doc)
             _event.transaction = txn
             events[idx] = _event
+            del event
         params = (events, txn)
         try:
             callback(*params[:param_nb])  # type: ignore[arg-type]

--- a/python/pycrdt/_provider.py
+++ b/python/pycrdt/_provider.py
@@ -129,6 +129,7 @@ class Provider:
         async with self._doc.events() as events:
             async for event in events:
                 message = create_update_message(event.update)
+                del event
                 await self._channel.send(message)
 
     async def __aenter__(self) -> Provider:


### PR DESCRIPTION
## Summary

The raw yrs events exposed to Python (`MapEvent`, `ArrayEvent`, `TextEvent`,
`TransactionEvent`) are declared `#[pyclass(unsendable)]`. PyO3 therefore
reports an unraisable `RuntimeError` if such an event is dropped on a thread
other than the one that created it:

```
RuntimeError: pycrdt::doc::TransactionEvent is unsendable, but is being dropped on another thread
```

Two code paths keep a raw event alive longer than necessary:

- `observe_callback` / `observe_deep_callback` (`_base.py`) hold the raw event
  until the user callback returns, even though its data has already been copied
  into the Python wrapper.
- `Provider._send_updates` (`_provider.py`) holds the raw `TransactionEvent`
  across `await self._channel.send(message)`, even though only `event.update`
  (bytes) is needed afterwards.

Under a multi-threaded async runtime (e.g. anyio worker threads), the callback
or the awaited continuation can resume on a different thread, so the raw event
is then dropped there and triggers the unsendable error above. This happens
**even with `allow_multithreading=True`** — that flag makes the shared types
usable across threads, but does not prevent a raw event from being dropped on a
foreign thread.

## Fix

Drop the raw event explicitly on the emitting thread, once its data is no
longer needed (after copying into the Python wrapper for observe, after
extracting the update bytes for the provider). This removes any window in which
the event could be dropped on another thread. Three `del event` statements, no
behavior change for single-threaded use.

## Reproduction (before this PR)

```python
import gc, queue, threading
import anyio
import pycrdt

def main():
    holder = queue.Queue()
    errors = []

    async def run():
        doc = pycrdt.Doc(allow_multithreading=True)
        m = doc.get("m", type=pycrdt.Map)

        async def consume():
            n = 0
            async with doc.events() as events:
                async for event in events:
                    holder.put(event)   # keep the raw TransactionEvent
                    n += 1
                    if n >= 3:
                        return

        async with anyio.create_task_group() as tg:
            tg.start_soon(consume)
            await anyio.sleep(0.05)
            for i in range(5):
                m[f"k{i}"] = i
                await anyio.sleep(0.01)

    anyio.run(run)

    def drop_other_thread():
        try:
            while True:
                ev = holder.get_nowait()
                del ev
                gc.collect()
        except queue.Empty:
            pass
        except BaseException as exc:
            errors.append(repr(exc))

    t = threading.Thread(target=drop_other_thread)
    t.start(); t.join(); gc.collect()
    print("errors:", errors)

main()
```

On `main`, dropping the raw event from another thread prints:

```
RuntimeError: pycrdt::doc::TransactionEvent is unsendable, but is being dropped on another thread
```

(The snippet keeps the raw event explicitly to make the cross-thread drop
deterministic; in real deployments the same drop happens implicitly when a
`Provider` or observe callback runs under a multi-threaded async runtime.)

## Testing

`pytest` passes with no regressions (the suite runs with
`filterwarnings = ["error"]`, so any unraisable warning would fail the run).

## Related

Same root cause as #110 (unsendable structs dropped on worker threads).
`allow_multithreading` (#137) addresses using the types across threads, but the
raw events emitted to callbacks / provider are still dropped on foreign threads;
this PR closes that remaining gap by not retaining them.
